### PR TITLE
Remove unnecessary functions

### DIFF
--- a/org-themis.el
+++ b/org-themis.el
@@ -322,16 +322,6 @@ project changes.")
   :keymap org-themis-mode-map
   :group 'org-themis)
 
-;;;###autoload
-(defun org-themis-mode-enable ()
-  "Enable `org-themis-mode'."
-  (org-themis-mode 1))
-
-;;;###autoload
-(defun org-themis-mode-disable ()
-  "Disable `org-themis-mode'."
-  (org-themis-mode 0))
-
 (provide 'org-themis)
 
 ;;; org-themis.el ends here


### PR DESCRIPTION
- We can toggle org-themis-mode enable/disable by `M-x org-themis-mode`
- They are not interactive functions so users use them as function, not command. They are hard to use.
